### PR TITLE
Adding support for numbers

### DIFF
--- a/bloomfilter.js
+++ b/bloomfilter.js
@@ -42,7 +42,7 @@
   };
 
   BloomFilter.prototype.add = function(v) {
-    var l = this.locations(v),
+    var l = this.locations(v.toString()),
         i = -1,
         k = this.k,
         buckets = this.buckets;
@@ -50,7 +50,7 @@
   };
 
   BloomFilter.prototype.test = function(v) {
-    var l = this.locations(v),
+    var l = this.locations(v.toString()),
         i = -1,
         k = this.k,
         b,

--- a/test/bloomfilter-test.js
+++ b/test/bloomfilter-test.js
@@ -42,7 +42,13 @@ suite.addBatch({
       var f = new BloomFilter(20, 10);
       f.add("abc");
       assert.equal(f.test("wtf"), false);
-    }
+    },
+		"works with integer types": function() {
+			var f = new BloomFilter(1000, 4);
+			f.add(1);
+			assert.equal(f.test(1), true);
+			assert.equal(f.test(2), false);
+		}
   }
 });
 


### PR DESCRIPTION
Previously, using the filter with number types instead of strings returned true for all test calls. Seems reasonable to be able to use the bloomfilter with numeric types as well.
