### PR TITLE
Update bloomfilter.js

### DIFF
--- a/bloomfilter.js
+++ b/bloomfilter.js
@@ -11,7 +11,7 @@
     this.k = k;
     var n = Math.ceil(m / 32);
     if (typedArrays) {
-      var buffer = new ArrayBuffer(32 * n),
+      var buffer = new ArrayBuffer(4 * n),
           kbytes = 1 << Math.ceil(Math.log(Math.ceil(Math.log(m) / Math.LN2 / 8)) / Math.LN2),
           array = kbytes === 1 ? Uint8Array : kbytes === 2 ? Uint16Array : Uint32Array,
           kbuffer = new ArrayBuffer(kbytes * k);


### PR DESCRIPTION
Buffer size is 8 times larger than required.

Reasoning:
   'var n = Math.ceil(m / 32);' <- n is size in double words
   ArrayBuffer takes size in bytes. Convert double word size to byte size = multiplying by 4.

Current code converted double word back to bits.
