### PR TITLE
Serialisation/deserialisation. Fixes #2

### DIFF
--- a/bloomfilter.js
+++ b/bloomfilter.js
@@ -1,5 +1,6 @@
 (function(exports) {
   exports.BloomFilter = BloomFilter;
+  exports.fromBytestream = fromBytestream;
   exports.fnv_1a = fnv_1a;
   exports.fnv_1a_b = fnv_1a_b;
 
@@ -62,6 +63,62 @@
     }
     return true;
   };
+
+  BloomFilter.prototype.toBytestream = function() {
+    var res = [],
+        buckets = this.buckets,
+        i,
+        j;
+
+    for(i = 0; i < 4; i++) {
+      res.push((this.m >> 8*i) & 255);
+    }
+
+    for(i = 0; i < 2; i++) {
+      res.push((this.k >> 8*i) & 255);
+    }
+
+    for(j = 0; j < buckets.length; j++) {
+      for(i = 0; i < 4; i++) {
+        res.push((buckets[j] >> 8*i) & 255);
+      }
+    }
+
+    return res;
+  };
+
+  function fromBytestream(bytes) {
+    var m = 0,
+        k = 0,
+        idx = 0,
+        i,
+        j;
+
+    for(i = 3; i >= 0; i--) {
+      m = m << 8;
+      m = m | (bytes[idx + i] & 255);
+    }
+    idx += 4;
+
+    for(i = 1; i >= 0; i--) {
+      k = k << 8;
+      k = k | (bytes[idx + i] & 255);
+    }
+    idx += 2;
+
+    var bloom = new BloomFilter(m,k),
+        buckets = bloom.buckets;
+
+    for(j = 0; j < buckets.length; j++) {
+      for(i = 3; i >= 0; i--) {
+        buckets[j] = buckets[j] << 8;
+        buckets[j] = buckets[j] | (bytes[idx + i] & 255);
+      }
+      idx += 4;
+    }
+
+    return bloom;
+  }
 
   // Fowler/Noll/Vo hashing.
   function fnv_1a(v) {

--- a/test/bloomfilter-test.js
+++ b/test/bloomfilter-test.js
@@ -1,7 +1,8 @@
 var bf = require("../bloomfilter"),
     BloomFilter = bf.BloomFilter,
     fnv_1a = bf.fnv_1a,
-    fnv_1a_b = bf.fnv_1a_b;
+    fnv_1a_b = bf.fnv_1a_b,
+    fromBytestream = bf.fromBytestream;
 
 var vows = require("vows"),
     assert = require("assert");
@@ -48,6 +49,14 @@ suite.addBatch({
       f.add(1);
       assert.equal(f.test(1), true);
       assert.equal(f.test(2), false);
+    },
+    "can be serialized": function() {
+      var f = new BloomFilter(1000, 4);
+      f.add(1);
+      var b = f.toBytestream();
+      var g = fromBytestream(b);
+      assert.equal(g.test(1), true);
+      assert.equal(g.test(2), false);
     }
   }
 });


### PR DESCRIPTION
Added code to convert a bloomfilter to a Array of bytes and reconstruct
a bloomfilter from such an array.

I am not a very experienced Javascript programmer and I am looking forward to comments about stylistic and technical problems with my code.

In particular there seem to be different ways of representing binary data: 
http://blog.n01se.net/blog-n01se-net-p-248.html
I like the array of bytes better than the unicode string, but on the other hand things like window.btoa seem to expect an unicode string.
