### PR TITLE
Improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var array = [].slice.call(bloom.buckets),
 // Deserialisation. Note that the any array-like object is supported, but
 // this will be used directly, so you may wish to use a typed array for
 // performance.
-var bloom = new BloomFilter(array, 3);
+var bloom = new BloomFilter(array, 16);
 ```
 
 Implementation

--- a/README.md
+++ b/README.md
@@ -7,31 +7,33 @@ This JavaScript bloom filter implementation uses the non-cryptographic
 Usage
 -----
 
-    var bloom = new BloomFilter(
-      32 * 256, // number of bits to allocate.
-      16        // number of hash functions.
-    );
+```javascript
+var bloom = new BloomFilter(
+  32 * 256, // number of bits to allocate.
+  16        // number of hash functions.
+);
 
-    // Add some elements to the filter.
-    bloom.add("foo");
-    bloom.add("bar");
+// Add some elements to the filter.
+bloom.add("foo");
+bloom.add("bar");
 
-    // Test if an item is in our filter.
-    // Returns true if an item is probably in the set,
-    // or false if an item is definitely not in the set.
-    bloom.test("foo");
-    bloom.test("bar");
-    bloom.test("blah");
+// Test if an item is in our filter.
+// Returns true if an item is probably in the set,
+// or false if an item is definitely not in the set.
+bloom.test("foo");
+bloom.test("bar");
+bloom.test("blah");
 
-    // Serialisation. Note that bloom.buckets may be a typed array,
-    // so we convert to a normal array first.
-    var array = [].slice.call(bloom.buckets),
-        json = JSON.stringify(array);
+// Serialisation. Note that bloom.buckets may be a typed array,
+// so we convert to a normal array first.
+var array = [].slice.call(bloom.buckets),
+    json = JSON.stringify(array);
 
-    // Deserialisation. Note that the any array-like object is supported, but
-    // this will be used directly, so you may wish to use a typed array for
-    // performance.
-    var bloom = new BloomFilter(array, 3);
+// Deserialisation. Note that the any array-like object is supported, but
+// this will be used directly, so you may wish to use a typed array for
+// performance.
+var bloom = new BloomFilter(array, 3);
+```
 
 Implementation
 --------------


### PR DESCRIPTION
Two small modifications to the README.md document:
- Syntax highlighting for the example snippet.
- Consistent value for the two calls to the constructor (otherwise it's unclear what the second parameter is in the second call).
