### PR TITLE
Fix excessively high rate of false positives

### DIFF
--- a/bloomfilter.js
+++ b/bloomfilter.js
@@ -1,7 +1,6 @@
 (function(exports) {
   exports.BloomFilter = BloomFilter;
   exports.fnv_1a = fnv_1a;
-  exports.fnv_1a_b = fnv_1a_b;
 
   var typedArrays = typeof ArrayBuffer !== "undefined";
 
@@ -40,7 +39,7 @@
         m = this.m,
         r = this._locations,
         a = fnv_1a(v),
-        b = fnv_1a_b(a),
+        b = fnv_1a(v, 1576284489), // The seed value is chosen randomly
         x = a % m;
     for (var i = 0; i < k; ++i) {
       r[i] = x < 0 ? (x + m) : x;
@@ -85,8 +84,11 @@
   }
 
   // Fowler/Noll/Vo hashing.
-  function fnv_1a(v) {
-    var a = 2166136261;
+  // Nonstandard variation: this function optionally takes a seed value that is incorporated
+  // into the offset basis. According to http://www.isthe.com/chongo/tech/comp/fnv/index.html
+  // "almost any offset_basis will serve so long as it is non-zero".
+  function fnv_1a(v, seed) {
+    var a = 2166136261 ^ (seed || 0);
     for (var i = 0, n = v.length; i < n; ++i) {
       var c = v.charCodeAt(i),
           d = c & 0xff00;
@@ -99,11 +101,6 @@
   // a * 16777619 mod 2**32
   function fnv_multiply(a) {
     return a + (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24);
-  }
-
-  // One additional iteration of FNV, given a hash.
-  function fnv_1a_b(a) {
-    return fnv_mix(fnv_multiply(a));
   }
 
   // See https://web.archive.org/web/20131019013225/http://home.comcast.net/~bretm/hash/6.html

--- a/test/bloomfilter-test.js
+++ b/test/bloomfilter-test.js
@@ -1,7 +1,6 @@
 var bf = require("../bloomfilter"),
     BloomFilter = bf.BloomFilter,
-    fnv_1a = bf.fnv_1a,
-    fnv_1a_b = bf.fnv_1a_b;
+    fnv_1a = bf.fnv_1a;
 
 var vows = require("vows"),
     assert = require("assert");
@@ -52,9 +51,9 @@ suite.addBatch({
     "size": function() {
       var f = new BloomFilter(1000, 4), i = -1;
       for (var i = 0; i < 100; ++i) f.add(i);
-      assert.inDelta(f.size(), 99.953102, 1e-6);
+      assert.inDelta(f.size(), 100, 6);
       for (var i = 0; i < 1000; ++i) f.add(i);
-      assert.inDelta(f.size(), 950.424571, 1e-6);
+      assert.inDelta(f.size(), 1000, 100);
     }
   }
 });


### PR DESCRIPTION
This PR fixes the problem highlighted in #15, namely that the current bloom filter implementation has many more false positives than predicted by the theory.

Here is a script that compares the [expected false positive rate](https://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives) to the actual rate (takes about 15 seconds to run on my machine). With the parameters given here, the actual false positive rate is approximately 150 times what it should be.

```js
const { BloomFilter, fnv_1a } = require('bloomfilter')

const n = 1000000;  // number of items in set
const m = 28755176; // number of bits in filter
const k = 20;       // number of hash functions
const max = 1e7;    // items in set are of the form 'K' + i, where 0 <= i < max

console.log('Expected false positive rate: ' + Math.exp(-Math.LN2 * Math.LN2 * m / n).toFixed(7))

let bloom = new BloomFilter(m, k);
let vals = {}, hashes = {};

for (let i = 0; i < 1000000; i++) {
  let val = 'K' + Math.floor(Math.random() * max);
  bloom.add(val);
  vals[val] = true;
  hashes['H' + fnv_1a(val)] = val;
}

let count = 0, collisions = 0;

for (let i = 0; i < max; i++) {
  let val = 'K' + i;
  if (bloom.test(val) && !vals[val]) {
    count++;
    let hash = 'H' + fnv_1a(val);
    if (hashes[hash] && hashes[hash] !== val) {
      collisions++;
    }
  }
}

console.log('Actual false positive rate:   ' + (1.0 * count / max).toFixed(7))
console.log(collisions + ' out of ' + count + ' false positives were due to FNV collisions')
```

The reason why this happens is that the locations of the bloom filter bits for a particular entry are not independent pseudorandom values as they should be. In particular, if you have two strings that have a FNV collision (for example, `fnv_1a('K3040109') == fnv_1a('K5338215') == 8754595`), then their `fnv_1a_b` values will also be equal (since `fnv_1a_b` depends only on the result of the first hash). Hence, the Bloom filter bit locations for all of the colliding strings will always be the same:

```js
var bloom = new BloomFilter(1000, 4)
bloom.add('K3040109')
bloom.test('K5338215') // false positive: always returns true
```

To correctly implement Bloom filter characteristics, the two hash functions must be independent — that is, even if two strings have a collision on the first hash, it is very unlikely that they also have a
collision on the second hash.

I think the simplest way of implementing this with FNV is to use two different base offsets for the two hash functions. I have done this in the attached patch. I think this is reasonable because the base offset is chosen essentially arbitrarily (according to the [FNV website](http://www.isthe.com/chongo/tech/comp/fnv/index.html), the standard base offset is a hash of one of the authors' email signature). The seed I set for the second hash function was generated with `Math.ceil(Math.random() * 0xffffffff)` — in the fine tradition of [XKCD 221](https://www.xkcd.com/221/)!

With this patch, the script above shows a false positive rate that is more in line with what's expected.